### PR TITLE
Add note about prepping package manager before install

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A tool for getting your desired pairing configuraton ready. Ideal for users of a
 * Install ansible requirements: `ansible-galaxy install -r requirements.yml`
 * Launch a new ec2 instance (ubuntu is currently supported), download your new keypair `something.pem` file.
 * Add the `something.pem` to your SSH identities: `ssh-add something.pem`
+* Connect to ec2 instance and run `sudo apt-get update` to ensure package
+  manager is up-to-date
 * Update the configuration to meet your needs `ansible/hosts.yaml`:
   * public dns name of your host.
   * users and public keys using the server


### PR DESCRIPTION
### What

Add a small note about connecting to your new ec2 instance and updating `apt` before running `bin/install`.

### Why

For the `ansible` install to work correctly, `apt` must be up-to-date.

@raymondberg